### PR TITLE
Sprint 001 Task 1.3.5: Package.json ESM Configuration and Module Type Warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,34 +2,35 @@
   "name": "astro-stack-auth",
   "version": "0.1.0",
   "description": "Stack Auth integration for Astro",
-  "main": "./dist/index.js",
+  "type": "module",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     },
     "./server": {
       "types": "./dist/server.d.ts",
       "import": "./dist/server.mjs",
-      "require": "./dist/server.js"
+      "require": "./dist/server.cjs"
     },
     "./client": {
       "types": "./dist/client.d.ts",
       "import": "./dist/client.mjs",
-      "require": "./dist/client.js"
+      "require": "./dist/client.cjs"
     },
     "./components": {
       "types": "./dist/components.d.ts",
       "import": "./dist/components.mjs",
-      "require": "./dist/components.js"
+      "require": "./dist/components.cjs"
     },
     "./middleware": {
       "types": "./dist/middleware.d.ts",
       "import": "./dist/middleware.mjs",
-      "require": "./dist/middleware.js"
+      "require": "./dist/middleware.cjs"
     }
   },
   "files": [

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -68,10 +68,10 @@ function testBuildFilesExist() {
   });
   
   for (const entryPoint of ENTRY_POINTS) {
-    smokeTest(`${entryPoint}.js exists`, () => {
-      const filePath = path.join(DIST_DIR, `${entryPoint}.js`);
+    smokeTest(`${entryPoint}.cjs exists`, () => {
+      const filePath = path.join(DIST_DIR, `${entryPoint}.cjs`);
       if (!fs.existsSync(filePath)) {
-        throw new Error(`Missing CommonJS build output: ${entryPoint}.js`);
+        throw new Error(`Missing CommonJS build output: ${entryPoint}.cjs`);
       }
     });
     
@@ -100,8 +100,8 @@ function testModuleImports() {
   log('info', 'Running module import tests...');
   
   for (const entryPoint of ENTRY_POINTS) {
-    smokeTest(`Can require ${entryPoint}.js`, () => {
-      const modulePath = path.join(DIST_DIR, `${entryPoint}.js`);
+    smokeTest(`Can require ${entryPoint}.cjs`, () => {
+      const modulePath = path.join(DIST_DIR, `${entryPoint}.cjs`);
       delete require.cache[path.resolve(modulePath)];
       const module = require(modulePath);
       
@@ -126,7 +126,7 @@ function testModuleFunctionality() {
   
   // Test index module
   smokeTest('Index module exports integration function', () => {
-    const modulePath = path.join(DIST_DIR, 'index.js');
+    const modulePath = path.join(DIST_DIR, 'index.cjs');
     delete require.cache[path.resolve(modulePath)];
     const module = require(modulePath);
     
@@ -142,7 +142,7 @@ function testModuleFunctionality() {
   
   // Test server module
   smokeTest('Server module exports auth functions', () => {
-    const modulePath = path.join(DIST_DIR, 'server.js');
+    const modulePath = path.join(DIST_DIR, 'server.cjs');
     delete require.cache[path.resolve(modulePath)];
     const module = require(modulePath);
     
@@ -156,7 +156,7 @@ function testModuleFunctionality() {
   
   // Test client module
   smokeTest('Client module exports auth functions', () => {
-    const modulePath = path.join(DIST_DIR, 'client.js');
+    const modulePath = path.join(DIST_DIR, 'client.cjs');
     delete require.cache[path.resolve(modulePath)];
     const module = require(modulePath);
     
@@ -170,7 +170,7 @@ function testModuleFunctionality() {
   
   // Test components module 
   smokeTest('Components module has valid exports', () => {
-    const modulePath = path.join(DIST_DIR, 'components.js');
+    const modulePath = path.join(DIST_DIR, 'components.cjs');
     delete require.cache[path.resolve(modulePath)];
     const module = require(modulePath);
     
@@ -182,7 +182,7 @@ function testModuleFunctionality() {
 
   // Test middleware module 
   smokeTest('Middleware module has valid exports', () => {
-    const modulePath = path.join(DIST_DIR, 'middleware.js');
+    const modulePath = path.join(DIST_DIR, 'middleware.cjs');
     delete require.cache[path.resolve(modulePath)];
     const module = require(modulePath);
     
@@ -202,8 +202,8 @@ function testFileSizes() {
   log('info', 'Running file size tests...');
   
   for (const entryPoint of ENTRY_POINTS) {
-    smokeTest(`${entryPoint}.js has reasonable size`, () => {
-      const filePath = path.join(DIST_DIR, `${entryPoint}.js`);
+    smokeTest(`${entryPoint}.cjs has reasonable size`, () => {
+      const filePath = path.join(DIST_DIR, `${entryPoint}.cjs`);
       const stats = fs.statSync(filePath);
       
       if (stats.size === 0) {
@@ -300,7 +300,7 @@ function testIntegrationSmoke() {
   log('info', 'Running integration smoke tests...');
   
   smokeTest('Integration can be called with options', () => {
-    const modulePath = path.join(DIST_DIR, 'index.js');
+    const modulePath = path.join(DIST_DIR, 'index.cjs');
     delete require.cache[path.resolve(modulePath)];
     const module = require(modulePath);
     

--- a/scripts/type-check-all-configs.js
+++ b/scripts/type-check-all-configs.js
@@ -10,9 +10,13 @@
  * Task: 1.2.4 - React Type Integration Testing
  */
 
-const { spawn } = require('child_process');
-const path = require('path');
-const fs = require('fs');
+import { spawn } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const configs = [
   'tsconfig.json',
@@ -230,14 +234,14 @@ async function main() {
   }
 }
 
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch(error => {
     console.error('💥 Script failed:', error);
     process.exit(1);
   });
 }
 
-module.exports = {
+export {
   runTypeCheck,
   validateTestFiles,
   validateConfigs,

--- a/scripts/validate-build.js
+++ b/scripts/validate-build.js
@@ -30,15 +30,15 @@ const EXPECTED_ENTRY_POINTS = [
 
 // Expected file formats
 const EXPECTED_FORMATS = [
-  '.js',   // CommonJS
+  '.cjs',  // CommonJS
   '.mjs',  // ESM
   '.d.ts', // TypeScript declarations
-  '.d.mts' // TypeScript ESM declarations
+  '.d.cts' // TypeScript CJS declarations
 ];
 
 // Expected source map files
 const EXPECTED_SOURCE_MAPS = [
-  '.js.map',
+  '.cjs.map',
   '.mjs.map'
 ];
 
@@ -255,7 +255,7 @@ function runSmokeTests() {
   
   // Test main integration export
   try {
-    const mainModule = require(path.join(DIST_DIR, 'index.js'));
+    const mainModule = require(path.join(DIST_DIR, 'index.cjs'));
     
     if (!mainModule.default && !mainModule.stackAuth) {
       warnings.push('Main module does not export expected integration function');
@@ -268,7 +268,7 @@ function runSmokeTests() {
   
   // Test server module exports
   try {
-    const serverModule = require(path.join(DIST_DIR, 'server.js'));
+    const serverModule = require(path.join(DIST_DIR, 'server.cjs'));
     
     const expectedServerExports = ['getUser', 'requireAuth', 'getSession'];
     for (const exportName of expectedServerExports) {
@@ -284,7 +284,7 @@ function runSmokeTests() {
   
   // Test client module exports
   try {
-    const clientModule = require(path.join(DIST_DIR, 'client.js'));
+    const clientModule = require(path.join(DIST_DIR, 'client.cjs'));
     
     const expectedClientExports = ['signIn', 'signOut', 'redirectToSignIn', 'redirectToSignUp'];
     for (const exportName of expectedClientExports) {

--- a/scripts/validate-types.js
+++ b/scripts/validate-types.js
@@ -241,7 +241,7 @@ function validateDeclarationFileSyntax() {
   
   for (const entryPoint of ENTRY_POINTS) {
     const dtsFile = path.join(DIST_DIR, `${entryPoint}.d.ts`);
-    const dmtsFile = path.join(DIST_DIR, `${entryPoint}.d.mts`);
+    const dctsFile = path.join(DIST_DIR, `${entryPoint}.d.cts`);
     
     // Validate .d.ts file
     if (fs.existsSync(dtsFile)) {
@@ -283,18 +283,18 @@ function validateDeclarationFileSyntax() {
       errors.push(`Missing declaration file: ${entryPoint}.d.ts`);
     }
     
-    // Validate .d.mts file
-    if (fs.existsSync(dmtsFile)) {
+    // Validate .d.cts file
+    if (fs.existsSync(dctsFile)) {
       try {
-        const content = fs.readFileSync(dmtsFile, 'utf8');
+        const content = fs.readFileSync(dctsFile, 'utf8');
         if (!content.trim()) {
-          warnings.push(`${entryPoint}.d.mts is empty`);
+          warnings.push(`${entryPoint}.d.cts is empty`);
         }
       } catch (error) {
-        errors.push(`Failed to read ${entryPoint}.d.mts: ${error.message}`);
+        errors.push(`Failed to read ${entryPoint}.d.cts: ${error.message}`);
       }
     } else {
-      errors.push(`Missing ESM declaration file: ${entryPoint}.d.mts`);
+      errors.push(`Missing CJS declaration file: ${entryPoint}.d.cts`);
     }
   }
   

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   outDir: 'dist',
+  // Use .cjs extension for CommonJS files when package.json has "type": "module"
+  outExtension({ format }) {
+    return {
+      js: format === 'cjs' ? '.cjs' : '.mjs'
+    }
+  },
   // Configure TypeScript to be more permissive for external dependencies
   tsconfig: './tsconfig.build.json',
   external: [


### PR DESCRIPTION
## Summary
Resolves Node.js module type warnings and improves ESM compatibility by adding proper package.json configuration.

## Changes Made
- Added `"type": "module"` to package.json for proper ESM module designation
- Updated tsup config to generate `.cjs` files for CommonJS output using `outExtension`
- Updated package.json exports to reference `.cjs` files instead of `.js` files
- Converted `scripts/type-check-all-configs.js` from CommonJS to ESM syntax
- Updated build validation scripts to expect `.cjs` and `.d.cts` files

## Testing
- ✅ All build validation tests pass
- ✅ All type validation tests pass
- ✅ All smoke tests pass (39/39)
- ✅ Package can be consumed by both ESM and CommonJS consumers
- ✅ No more Node.js module type warnings

## Fixes
Resolves module type warnings:
```
Warning: Module type of file:///home/jchen/repos/stack-auth-astro/scripts/validate-types.js is not specified and it doesn't parse as CommonJS.
```

🤖 Generated with [Claude Code](https://claude.ai/code)