### PR TITLE
Sprint 001 Task 1.2.15: Fix Consumer Configuration Dynamic Test Execution

### DIFF
--- a/tests/integration/consumer-config-validation.test.ts
+++ b/tests/integration/consumer-config-validation.test.ts
@@ -101,8 +101,8 @@ describe('Consumer Configuration Validation', () => {
       declare const signIn: typeof import('astro-stack-auth/client').signIn;
       declare const signOut: typeof import('astro-stack-auth/client').signOut;
       
-      // Test component imports (React types)
-      declare const SignIn: typeof import('astro-stack-auth/components').SignIn;
+      // Test component types import (available in Sprint 001)
+      import type { StackAuthFC } from 'astro-stack-auth/components';
       
       // Test configuration
       const config: StackAuthConfig = {
@@ -122,9 +122,19 @@ describe('Consumer Configuration Validation', () => {
     const testFilePath = path.join(process.cwd(), 'temp-consumer-test.ts');
     require('fs').writeFileSync(testFilePath, testCode);
 
+    // Create a temporary tsconfig that extends the recommended config and includes our test file
+    const tempConfigPath = path.join(process.cwd(), 'temp-tsconfig.json');
+    const tempConfig = {
+      extends: './test-configs/tsconfig.recommended.json',
+      include: [
+        './temp-consumer-test.ts'
+      ]
+    };
+    require('fs').writeFileSync(tempConfigPath, JSON.stringify(tempConfig, null, 2));
+
     try {
-      // Test with recommended config
-      execSync(`npx tsc --noEmit --project test-configs/tsconfig.recommended.json temp-consumer-test.ts`, {
+      // Test with temporary config that includes our test file
+      execSync(`npx tsc --noEmit --project ${tempConfigPath}`, {
         stdio: 'pipe',
         timeout: 30000
       });
@@ -132,9 +142,14 @@ describe('Consumer Configuration Validation', () => {
       // If we reach here, the test passed
       expect(true).toBe(true);
     } finally {
-      // Clean up test file
+      // Clean up test files
       try {
         require('fs').unlinkSync(testFilePath);
+      } catch (e) {
+        // Ignore cleanup errors
+      }
+      try {
+        require('fs').unlinkSync(tempConfigPath);
       } catch (e) {
         // Ignore cleanup errors
       }


### PR DESCRIPTION
## Summary
- Fix TypeScript command mixing --project flag with source files  
- Create temporary tsconfig that extends recommended config for dynamic tests
- Update component import test to use available types instead of non-existent components
- All consumer integration validation tests now pass

## Test Results
✅ All consumer integration validation tests pass (14/14)
✅ Dynamic TypeScript compilation works correctly for consumer scenarios  
✅ tsconfig.recommended.json validated for consumer test contexts

## Root Causes Fixed
1. **TS5042 Error**: Incorrect tsc command syntax mixing --project with source files
2. **Missing Components**: Test attempted to import SignIn component that doesn't exist in Sprint 001

## Technical Changes
- Created temporary tsconfig that extends recommended configuration 
- Updated import test to use available StackAuthFC type instead of SignIn component
- Added proper cleanup for temporary files

🤖 Generated with [Claude Code](https://claude.ai/code)

Closes #62